### PR TITLE
fix install directives

### DIFF
--- a/tools/cmake/common.cmake
+++ b/tools/cmake/common.cmake
@@ -131,7 +131,7 @@ if(WIN32)
  
 	install(TARGETS ${APP}
 		RUNTIME DESTINATION bin
-		CONFIGURATIONS All)
+	)
  
 	install(DIRECTORY ${CMAKE_SOURCE_DIR}/dist/Media
 		DESTINATION ./
@@ -187,7 +187,7 @@ if(UNIX)
  
 	install(TARGETS ${APP}
 		RUNTIME DESTINATION bin
-		CONFIGURATIONS All)
+	)
  
 	install(DIRECTORY ${CMAKE_SOURCE_DIR}/dist/media
 		DESTINATION ./

--- a/tools/cmake/common.cmake
+++ b/tools/cmake/common.cmake
@@ -107,7 +107,7 @@ include_directories( ${OIS_INCLUDE_DIRS}
 )
  
 if(MINGW OR UNIX)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist/bin)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dist/bin)
 endif(MINGW OR UNIX)
 
 add_executable(${APP} WIN32 ${HDRS} ${SRCS})

--- a/tools/cmake/common.cmake
+++ b/tools/cmake/common.cmake
@@ -106,6 +106,10 @@ include_directories( ${OIS_INCLUDE_DIRS}
 	${OGRE_Overlay_INCLUDE_DIRS}
 )
  
+if(MINGW OR UNIX)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist/bin)
+endif(MINGW OR UNIX)
+
 add_executable(${APP} WIN32 ${HDRS} ${SRCS})
  
 set_target_properties(${APP} PROPERTIES DEBUG_POSTFIX _d)
@@ -123,10 +127,6 @@ if(WIN32 AND NOT MINGW)
 		COMMAND copy \"$(TargetPath)\" .\\dist\\bin )
 endif(WIN32 AND NOT MINGW)
 
-if(MINGW OR UNIX)
-	set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/dist/bin)
-endif(MINGW OR UNIX)
- 
 if(WIN32)
  
 	install(TARGETS ${APP}


### PR DESCRIPTION
in order to use other cmake features (like cpack), install should work correctly.
1. remove configurations all from target, since afaik there is no all option in cmake (install does not work correctly)
2. change executable_output_path to cmake_runtime_output_directory to make install work
